### PR TITLE
Add Alias key to the desktop file

### DIFF
--- a/data/org.gnome.Nautilus.desktop.in.in
+++ b/data/org.gnome.Nautilus.desktop.in.in
@@ -15,3 +15,4 @@ X-GNOME-Bugzilla-Product=nautilus
 X-GNOME-Bugzilla-Component=general
 X-GNOME-Bugzilla-Version=@VERSION@
 X-GNOME-UsesNotifications=true
+X-Endless-Alias=eos-file-manager


### PR DESCRIPTION
We use the X-Endless-Alias key to point to the old name of the desktop
file, in order to transition existing settings from that to the new
name.

[endlessm/T6387]
