### PR TITLE
desktop.in.in: remove DBusActivatable=true

### DIFF
--- a/data/org.gnome.Nautilus.desktop.in.in
+++ b/data/org.gnome.Nautilus.desktop.in.in
@@ -6,7 +6,6 @@ Exec=nautilus --new-window %U
 Icon=system-file-manager
 Terminal=false
 Type=Application
-DBusActivatable=true
 StartupNotify=true
 Categories=GNOME;GTK;Utility;Core;FileManager;
 MimeType=inode/directory;application/x-gnome-saved-search;


### PR DESCRIPTION
For proper integration with Endless desktop launching.

https://phabricator.endlessm.com/T6387
