### PR TITLE
control.in: specify app ID as org.gnome.Nautilus

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -38,6 +38,7 @@ Standards-Version: 3.9.6
 
 Package: nautilus
 Architecture: any
+XCBS-EOS-AppId: org.gnome.Nautilus
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          nautilus-data (>= ${gnome:Version}),


### PR DESCRIPTION
To match desktop file name.

https://phabricator.endlessm.com/T6387
