### PR TITLE
file-operations: Use a GList** for the to_delete output parameter

### DIFF
--- a/libnautilus-private/nautilus-file-operations.c
+++ b/libnautilus-private/nautilus-file-operations.c
@@ -1975,7 +1975,7 @@ trash_file (CommonJob    *job,
             SourceInfo   *source_info,
             TransferInfo *transfer_info,
             gboolean      toplevel,
-            GList        *to_delete)
+            GList       **to_delete)
 {
 	GError *error;
 	char *primary, *secondary, *details;
@@ -2006,7 +2006,7 @@ trash_file (CommonJob    *job,
 	}
 
 	if (job->delete_all) {
-		to_delete = g_list_prepend (to_delete, file);
+		*to_delete = g_list_prepend (*to_delete, file);
 		goto skip;
 	}
 
@@ -2038,10 +2038,10 @@ trash_file (CommonJob    *job,
 	        *skipped_file = TRUE;
 		job->skip_all_error = TRUE;
 	} else if (response == 3) { /* delete all */
-		to_delete = g_list_prepend (to_delete, file);
+		*to_delete = g_list_prepend (*to_delete, file);
 		job->delete_all = TRUE;
 	} else if (response == 4) { /* delete */
-		to_delete = g_list_prepend (to_delete, file);
+		*to_delete = g_list_prepend (*to_delete, file);
 	}
 
 skip:
@@ -2087,7 +2087,7 @@ trash_files (CommonJob *job,
                 trash_file (job, file,
                             &skipped_file,
                             &source_info, &transfer_info,
-                            TRUE, to_delete);
+                            TRUE, &to_delete);
 		if (skipped_file) {
 			(*files_skipped)++;
 		}


### PR DESCRIPTION
The to_delete GList\* gets initialized in trash_files() and is supposed
to be filled by trash_file() so that we know which files we want to
delete directly when the call to g_file_trash() fails for some reason.

However, this GList\* gets modified in place by calls to g_list_prepend()
and so those changes will only be seen by the to_delete argument inside
trash_file(), but not by the local variable defined in trash_files(), which
will continue to point to NULL regardless of those changes.

So, we simply need to pass a reference to the GList\* so that any change done
to the structure of the GList\* inside trash_file() is seen in trash_files().

https://bugzilla.gnome.org/show_bug.cgi?id=766030

https://phabricator.endlessm.com/T11534
