### PR TITLE
Install Nautilus as the default MIME handler for inode/directory

### DIFF
--- a/debian/nautilus.postinst
+++ b/debian/nautilus.postinst
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+XDG_MIMEAPPS_FILE=/etc/xdg/mimeapps.list
+XDG_MIMEAPPS_HEADER="[Default Applications]"
+
+if [ "$1" = configure ]; then
+    if  [ -f ${XDG_MIMEAPPS_FILE} ]; then
+        cp -f ${XDG_MIMEAPPS_FILE} ${XDG_MIMEAPPS_FILE}.dpkg-new
+    fi
+
+    # First non-empty line should be the required header, otherwise the file
+    # will be considered corrupt and the process will exit with an error.
+    if [ -f ${XDG_MIMEAPPS_FILE}.dpkg-new ]; then
+        # Let's remove any empty lines to help checking the header first.
+        sed -i -e "/^[ \t]*$/d" ${XDG_MIMEAPPS_FILE}.dpkg-new
+        if [ "$(head -n 1 ${XDG_MIMEAPPS_FILE}.dpkg-new)" != "${XDG_MIMEAPPS_HEADER}" ]; then
+            # File found "corrupt", abort.
+            exit 1
+        fi
+    fi
+
+    # We need to add the required header when creating the file.
+    if [ ! -f ${XDG_MIMEAPPS_FILE}.dpkg-new ]; then
+        echo "${XDG_MIMEAPPS_HEADER}" > ${XDG_MIMEAPPS_FILE}.dpkg-new
+    fi
+
+    # Don't add a duplicate line in case the file already exists.
+    sed -i "/^inode\/directory=.*/d" ${XDG_MIMEAPPS_FILE}.dpkg-new
+    echo "inode/directory=org.gnome.Nautilus.desktop" >> ${XDG_MIMEAPPS_FILE}.dpkg-new
+
+    # Finally save a backup and replace the old file with the new one, atomically.
+    if [ -f ${XDG_MIMEAPPS_FILE} ]; then
+        if cmp -s ${XDG_MIMEAPPS_FILE} ${XDG_MIMEAPPS_FILE}.dpkg-new; then
+            # No changes: remove useless duplicated file.
+            rm -f ${XDG_MIMEAPPS_FILE}.dpkg-new
+        else
+            # Changes: atomically rename the files.
+            mv -f ${XDG_MIMEAPPS_FILE} ${XDG_MIMEAPPS_FILE}.dpkg-old
+            mv -f ${XDG_MIMEAPPS_FILE}.dpkg-new ${XDG_MIMEAPPS_FILE}
+        fi
+    else
+        # No previously existing file: nothing to backup.
+        mv -f ${XDG_MIMEAPPS_FILE}.dpkg-new ${XDG_MIMEAPPS_FILE}
+    fi
+fi
+
+#DEBHELPER#


### PR DESCRIPTION
Normally there are no default handlers explicitly set for this
MIME type, which means that GIO and others (e.g. xdg-utils) will
try to determine a fallback by inspecting the cached list of MIME
handlers available, until finding one that handles that type.

In the world of flatpak /var/lib/flatpak/exports/share is added
to the XDG_DATA_DIRS variable with more priority than /usr/share,
meaning that it's relatively easy to reach a situation where an
application would automatically became the "fallback default" over
one installed in the system for a given MIME type, unless the user
has explicitly defined a default application for it.

This has happened so far with the flatpak for Visual Studio, which
installs itself as a handler for inode/directory, also handled by
Nautilus (which is not a flatpak, and therefore its association to
this MIME type lives in /usr/share/applications/mimeinfo.cache). In
this scenario, installing Visual Studio means that, suddenly, trying
to open a directory using the "default" handler would result in VS
performing the action instead of Nautilus, which is very confusing.

This said, it probably makes sense for VS to install itself as a
handler for this MIME type since it serves a clear purpose [1], and
it also probably makes sense that flatpak installs it exports/share
directory in the XDG_DATA_DIRS with precedence over /usr/share (after
all, in a modern flatpak world you probably want to give priority to
whatever app the user installs explicitly over those in the base OS).

However, for the particular case of inode/directory MIME type, I think
it also makes sense to be able to explicitly "protect" the association
with Nautilus (at least in Endless OS, where it's the main file manager)
so that it's not that easy to replace it with another application just
because of being installed, without explicit user intervention.

For this reason, let's ensure that Nautilus gets added to a system-wide
list of explicit "default applications" (mimeapps.list) that will be
checked before falling back to mimeinfo.cache files, but after any
user-specified configuration that might have expliticly set by the user.

[1] https://github.com/Microsoft/vscode/issues/15741

https://phabricator.endlessm.com/T19888