### PR TITLE
Update to also allow building on top of tracker 2.0, besides 1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -249,13 +249,17 @@ AC_ARG_ENABLE(tracker,
               [enable_tracker=yes])
 
 if test "x$enable_tracker" != "xno"; then
-  if $PKG_CONFIG --exists tracker-sparql-1.0; then
-    PKG_CHECK_MODULES(TRACKER, tracker-sparql-1.0)
-  else 
-    if $PKG_CONFIG --exists tracker-sparql-0.18; then
-      PKG_CHECK_MODULES(TRACKER, tracker-sparql-0.18)
+  if $PKG_CONFIG --exists tracker-sparql-2.0; then
+    PKG_CHECK_MODULES(TRACKER, tracker-sparql-2.0)
+  else
+    if $PKG_CONFIG --exists tracker-sparql-1.0; then
+      PKG_CHECK_MODULES(TRACKER, tracker-sparql-1.0)
     else
-      PKG_CHECK_MODULES(TRACKER, tracker-sparql-0.16)
+      if $PKG_CONFIG --exists tracker-sparql-0.18; then
+        PKG_CHECK_MODULES(TRACKER, tracker-sparql-0.18)
+      else
+        PKG_CHECK_MODULES(TRACKER, tracker-sparql-0.16)
+      fi
     fi
   fi
   AC_DEFINE(ENABLE_TRACKER, 1, [Define to enable Tracker support])


### PR DESCRIPTION
We need this to get nautilus building again in master and while we
wait for the rebase on Nautilus 3.26, since tracker 1.0 is no longer
available. This change gets Nautilus building, linking and running.

https://phabricator.endlessm.com/T21852