### PR TITLE
Add X-Eos-Appid to control files

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -40,6 +40,7 @@ Standards-Version: 4.1.2
 
 Package: nautilus
 Architecture: any
+XBS-Eos-Appid: org.gnome.Nautilus
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          nautilus-data (= ${source:Version}),

--- a/debian/control.in
+++ b/debian/control.in
@@ -36,6 +36,7 @@ Standards-Version: 4.1.2
 
 Package: nautilus
 Architecture: any
+XBS-Eos-Appid: org.gnome.Nautilus
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          nautilus-data (= ${source:Version}),


### PR DESCRIPTION
During the transition to Nautilus 3.26.3, we accidentaly lost
the integration with the custom Endless content, due to the
desktop file renaming.

To fix that, add a X-Eos-Appid field to the Debian control
files. This will provide the necessary information to
dh_eoscontent to be able to correctly override the icon,
desktop file and contents of the Nautilus package.

https://phabricator.endlessm.com/T21964